### PR TITLE
fix(prop-types): make width and height prop conditionally required

### DIFF
--- a/lib/propTypes.js
+++ b/lib/propTypes.js
@@ -90,10 +90,11 @@ export const resizableProps: Object = {
   * */
   height: (...args) => {
     const [props] = args;
-    if (!['both', 'y'].includes(props.axis)) {
-      return PropTypes.number(...args);
+    // Required if resizing height or both
+    if (props.axis === 'both' || props.axis === 'y') {
+      return PropTypes.number.isRequired(...args);
     }
-    return PropTypes.number.isRequired(...args);
+    return PropTypes.number(...args);
   },
   /*
   * Customize cursor resize handle
@@ -149,9 +150,10 @@ export const resizableProps: Object = {
    */
   width: (...args) => {
     const [props] = args;
-    if (!['both', 'x'].includes(props.axis)) {
-      return PropTypes.number(...args);
+    // Required if resizing width or both
+    if (props.axis === 'both' || props.axis === 'x') {
+      return PropTypes.number.isRequired(...args);
     }
-    return PropTypes.number.isRequired(...args);
+    return PropTypes.number(...args);
   },
 };

--- a/lib/propTypes.js
+++ b/lib/propTypes.js
@@ -88,7 +88,13 @@ export const resizableProps: Object = {
   /*
   * Initial height
   * */
-  height: PropTypes.number.isRequired,
+  height: (...args) => {
+    const [props] = args;
+    if (!['both', 'y'].includes(props.axis)) {
+      return PropTypes.number(...args);
+    }
+    return PropTypes.number.isRequired(...args);
+  },
   /*
   * Customize cursor resize handle
   * */
@@ -141,5 +147,11 @@ export const resizableProps: Object = {
   /*
    * Initial width
    */
-  width: PropTypes.number.isRequired,
+  width: (...args) => {
+    const [props] = args;
+    if (!['both', 'x'].includes(props.axis)) {
+      return PropTypes.number(...args);
+    }
+    return PropTypes.number.isRequired(...args);
+  },
 };


### PR DESCRIPTION
Fixes https://github.com/react-grid-layout/react-resizable/issues/6

The issue was closed, but actually it's not fully fixed yet. My comment on the issue: https://github.com/react-grid-layout/react-resizable/issues/6#issuecomment-1102333307
