### PR TITLE
use node instead element because it is specified as node in ResizeCallbackData type definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ class Example extends React.Component {
   };
 
   // On top layout
-  onResize = (event, {element, size, handle}) => {
+  onResize = (event, {node, size, handle}) => {
     this.setState({width: size.width, height: size.height});
   };
 


### PR DESCRIPTION
Hello. 
I am just sending a fix about a little issue that I've seen in README.
Regards.