### PR TITLE
fix(propTypes): change offsetParent type from React Node to DOM Element

### DIFF
--- a/lib/propTypes.js
+++ b/lib/propTypes.js
@@ -75,7 +75,7 @@ export const resizableProps: Object = {
     children: PropTypes.node,
     disabled: PropTypes.bool,
     enableUserSelectHack: PropTypes.bool,
-    offsetParent: PropTypes.node,
+    offsetParent: PropTypes.instanceOf(Element),
     grid: PropTypes.arrayOf(PropTypes.number),
     handle: PropTypes.string,
     nodeRef: PropTypes.object,


### PR DESCRIPTION
resolves https://github.com/react-grid-layout/react-resizable/issues/219