### PR TITLE
chore(examples): add missing draggableOpts={{...}} example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import { ResizableBox } from 'react-resizable';
 class Example extends React.Component {
   render() {
     return (
-      <ResizableBox width={200} height={200} draggableOpts={{...}}
+      <ResizableBox width={200} height={200} draggableOpts={{grid: [25, 25]}}
           minConstraints={[100, 100]} maxConstraints={[300, 300]}>
         <span>Contents</span>
       </ResizableBox>


### PR DESCRIPTION
<img width="1114" alt="image" src="https://github.com/react-grid-layout/react-resizable/assets/60107091/61b7111c-381e-4581-b354-4dbab9e88234">

Got confused on the Example, since the draggableOpts was missing, and only found out about the options after browsing https://react-grid-layout.github.io/react-resizable/test/TestLayout.js