### PR TITLE
Added axis='none' to height and/or width changes so that Resizable and ResizableBox axis prop can be type 'none'

### DIFF
--- a/lib/propTypes.js
+++ b/lib/propTypes.js
@@ -91,7 +91,7 @@ export const resizableProps: Object = {
   height: (...args) => {
     const [props] = args;
     // Required if resizing height or both
-    if (props.axis === 'both' || props.axis === 'y') {
+    if (props.axis === 'both' || props.axis === 'y' || props.axis === 'none') {
       return PropTypes.number.isRequired(...args);
     }
     return PropTypes.number(...args);
@@ -151,7 +151,7 @@ export const resizableProps: Object = {
   width: (...args) => {
     const [props] = args;
     // Required if resizing width or both
-    if (props.axis === 'both' || props.axis === 'x') {
+    if (props.axis === 'both' || props.axis === 'x' || props.axis === 'none') {
       return PropTypes.number.isRequired(...args);
     }
     return PropTypes.number(...args);


### PR DESCRIPTION
<!-- 
Thanks for submitting a pull request to React-Resizable!

Please reference an open issue. If one has not been created, please create one along with a failing example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.
-->
The purpose of this Pull Request is to add the ability to assign type 'none' to axis for Resizable and ResizableBox.  Currently, 'none' is not a valid type for the axis prop.  
https://github.com/react-grid-layout/react-resizable/discussions#:~:text=%F0%9F%92%AC-,Axis%20type%20for%20ResizableBox%20does%20not%20include%20%22none%22,-jamcgre%20started%202