### PR TITLE
chore(dev): lift peerDep react-dom from react-draggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "react-draggable": "^4.0.3"
   },
   "peerDependencies": {
-    "react": ">= 16.3"
+    "react": ">= 16.3",
+    "react-dom": ">= 16.3"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
This fixes https://github.com/react-grid-layout/react-resizable/issues/245