### PR TITLE
fix: Reduce the required props for ResizableBox

### DIFF
--- a/__tests__/ResizableBox.test.tsx
+++ b/__tests__/ResizableBox.test.tsx
@@ -263,6 +263,18 @@ describe('render ResizableBox', () => {
     });
   });
 
+  test('renders with only width and height (all DefaultProps optional)', () => {
+    const {container} = render(
+      <ResizableBox width={200} height={100}>
+        <span />
+      </ResizableBox>
+    );
+    const divElement = container.querySelector('div');
+    expect(divElement).toHaveStyle({ width: '200px', height: '100px' });
+    // Default 'se' handle should be present
+    expect(container.querySelector('.react-resizable-handle-se')).toBeInTheDocument();
+  });
+
   describe('DOM updates after resize', () => {
     test('DOM width and height update after resize', async () => {
       const boxRef = React.createRef();

--- a/lib/propTypes.ts
+++ b/lib/propTypes.ts
@@ -46,7 +46,7 @@ export type ResizeHandleFn = (
   ref: React.RefObject<HTMLElement>,
 ) => React.ReactElement<any>;
 
-export type Props = DefaultProps & {
+export type Props = Partial<DefaultProps> & {
   children: React.ReactElement<any>;
   className?: string | null;
   draggableOpts?: Partial<React.ComponentProps<typeof DraggableCore>> | null;


### PR DESCRIPTION
* The only required props for ResizableBox should be height, width, and children. Previously the keys from DefaultProps were required as well.

closes: #263 

<!-- 
Thanks for submitting a pull request to React-Resizable!

Please reference an open issue. If one has not been created, please create one along with a failing example or test case.

Please do not commit built files (`/dist`) to pull requests. They are built only at release.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ResizableBox component now works with only width and height props—all other configuration options are optional.

* **Tests**
  * Added test case verifying the component renders correctly with minimal required props and includes default resize handles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-grid-layout/react-resizable/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->